### PR TITLE
skip score animation update if score value out of range (0-100 incl.)

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -254,8 +254,8 @@ socket.onmessage = event => {
 		scoreRed = scores.filter(s => s.id == 0 || s.id == 1).map(s => s.score).reduce((a, b) => a + b) / 2;
 		scoreBlue = scores.filter(s => s.id == 2 || s.id == 3).map(s => s.score).reduce((a, b) => a + b) / 2;
 
-		animation.red_score.update(scoreRed);
-		animation.blue_score.update(scoreBlue);
+		(scoreRed >= 0 && scoreRed <= 100) ? animation.red_score.update(scoreRed) : console.log("scoreRed out of range: " + scoreRed);
+		(scoreBlue >= 0 && scoreBlue <= 100) ? animation.blue_score.update(scoreBlue) : console.log("scoreBlue out of range: " + scoreBlue);
 
 		if (scoreRed > scoreBlue) {
 			red_score.style.fontWeight = 'bold';


### PR DESCRIPTION
Not entirely sure the cause of this, but hopefully this should at least avoid _displaying_ a ridiculous-looking value on screen. 

Example: 

https://user-images.githubusercontent.com/1176059/224564149-78c6a7a2-ef3c-4d90-b32c-f536687953eb.mp4

