### PR TITLE
fix progress position calculation and add smooth strain bar progress

### DIFF
--- a/main/css/style.css
+++ b/main/css/style.css
@@ -408,13 +408,19 @@ html {
 
 #progress {
 	position: absolute;
-	width: var(--bottom-width);
+	width: calc(2 * var(--bottom-width));
 	height: var(--footer-height);
 	padding: 0;
 	left: 0;
 	bottom: 0;
 	overflow: hidden;
 	transition: 500ms linear;
+	/*background: rgb(0,0,0);*/
+	/*mask-image: linear-gradient(90deg, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 50%, rgba(0,0,0,0) 100%);*/
+	-webkit-mask-image: linear-gradient(90deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 49.75%, transparent 50%);
+	mask-image: linear-gradient(90deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 49.75%, transparent 50%);
+	/*-webkit-mask-image: -webkit-gradient(linear, left, right,*/
+	/*from(rgba(0,0,0,1)), to(rgba(0,0,0,0)));*/
 }
 
 #chat-container {

--- a/main/css/style.css
+++ b/main/css/style.css
@@ -415,12 +415,8 @@ html {
 	bottom: 0;
 	overflow: hidden;
 	transition: 500ms linear;
-	/*background: rgb(0,0,0);*/
-	/*mask-image: linear-gradient(90deg, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 50%, rgba(0,0,0,0) 100%);*/
 	-webkit-mask-image: linear-gradient(90deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 49.75%, transparent 50%);
 	mask-image: linear-gradient(90deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 49.75%, transparent 50%);
-	/*-webkit-mask-image: -webkit-gradient(linear, left, right,*/
-	/*from(rgba(0,0,0,1)), to(rgba(0,0,0,0)));*/
 }
 
 #chat-container {

--- a/main/index.js
+++ b/main/index.js
@@ -237,7 +237,8 @@ socket.onmessage = event => {
 		last_strain_update = now;
 		seek = data.menu.bm.time.current;
 		if (scoreRed == 0 || scoreBlue == 0) {
-			progressChart.style.width = '0px';
+			progressChart.style.maskPosition = '-1220px 0px';
+			progressChart.style.webkitMaskPosition = '-1220px 0px';
 		}
 		else {
 			let maskPosition = `${-1220 + onepart * seek}px 0px`;

--- a/main/index.js
+++ b/main/index.js
@@ -232,7 +232,7 @@ socket.onmessage = event => {
 	}
 
 	let now = Date.now();
-	if (fulltime !== data.menu.bm.time.mp3) { fulltime = data.menu.bm.time.mp3; onepart = 1420 / fulltime; }
+	if (fulltime !== data.menu.bm.time.mp3) { fulltime = data.menu.bm.time.mp3; onepart = 1220 / fulltime; }
 	if (seek !== data.menu.bm.time.current && fulltime !== undefined && fulltime != 0 && now - last_strain_update > 500) {
 		last_strain_update = now;
 		seek = data.menu.bm.time.current;
@@ -240,8 +240,9 @@ socket.onmessage = event => {
 			progressChart.style.width = '0px';
 		}
 		else {
-			let width = onepart * seek + 'px';
-			progressChart.style.width = width;
+			let maskPosition = `${-1220 + onepart * seek}px 0px`;
+			progressChart.style.maskPosition = maskPosition;
+			progressChart.style.webkitMaskPosition = maskPosition;
 		}
 	}
 


### PR DESCRIPTION
The width of the progress bar wasn't updated when it went from 1420px to 1220px, leaving the progress bar calculation being wrong. This is now fixed.

I've also added a smoother looking animation to the progress bar moving, the previous method of using the container's width property does not do subpixel rendering and creates a slightly juddery movement. This PR also addresses that by using a moving mask instead of modifying the container's width property.

Example:

https://user-images.githubusercontent.com/1176059/226136371-9bdb702c-a6bb-4fc1-af89-7340b5ff8d5a.mp4



Also me:

https://user-images.githubusercontent.com/1176059/226136140-3916db62-8ae9-4923-8358-d440c6642182.mov

