### PR TITLE
Add slow pulse to last pick (and other misc. changes)

### DIFF
--- a/mappool/css/style.css
+++ b/mappool/css/style.css
@@ -172,6 +172,12 @@ html {
     }
 }
 
+@keyframes slowPulse {
+    50% {
+        opacity: 0.3;
+    }
+}
+
 .modIcon {
     position: absolute;
     top: 9px;

--- a/mappool/index.js
+++ b/mappool/index.js
@@ -145,6 +145,7 @@ socket.onmessage = async (event) => {
 
 async function setupBeatmaps() {
     hasSetup = true;
+    let lastPicked = null;
 
     const modsCount = {
         NM: 0,
@@ -189,9 +190,14 @@ async function setupBeatmaps() {
         bm.clicker.addEventListener('mousedown', function () {
             bm.clicker.addEventListener('click', function (event) {
                 if (!event.shiftKey) {
+                    if (lastPicked !== null) {
+                        lastPicked.blinkoverlay.style.animation = 'none';
+                    }
+                    lastPicked = bm;
                     bm.pickedStatus.style.color = '#f5f5f5';
                     bm.overlay.style.opacity = event.ctrlKey ? '0.95' : '0.85';
-                    bm.blinkoverlay.style.animation = event.ctrlKey ? 'none' : 'blinker 1s cubic-bezier(.36,.06,.01,.57) 300ms 8';
+                    bm.blinkoverlay.style.animation = event.ctrlKey ?
+                        'none' : 'blinker 1s cubic-bezier(.36,.06,.01,.57) 300ms 8, slowPulse 5000ms ease-in-out 8000ms infinite';
                     bm.artist.style.opacity = '0.3';
                     bm.title.style.opacity = '0.3';
                     bm.difficulty.style.opacity = '0.3';
@@ -221,9 +227,14 @@ async function setupBeatmaps() {
             });
             bm.clicker.addEventListener('contextmenu', function (event) {
                 if (!event.shiftKey) {
+                    if (lastPicked !== null) {
+                        lastPicked.blinkoverlay.style.animation = 'none';
+                    }
+                    lastPicked = bm;
                     bm.pickedStatus.style.color = '#f5f5f5';
                     bm.overlay.style.opacity = event.ctrlKey ? '0.95' : '0.85';
-                    bm.blinkoverlay.style.animation = event.ctrlKey ? 'none' : 'blinker 1s cubic-bezier(.36,.06,.01,.57) 300ms 8';
+                    bm.blinkoverlay.style.animation = event.ctrlKey ?
+                        'none' : 'blinker 1s cubic-bezier(.36,.06,.01,.57) 300ms 8, slowPulse 5000ms ease-in-out 8000ms infinite';
                     bm.artist.style.opacity = '0.3';
                     bm.title.style.opacity = '0.3';
                     bm.difficulty.style.opacity = '0.3';

--- a/mappool/index.js
+++ b/mappool/index.js
@@ -177,6 +177,36 @@ async function setupBeatmaps() {
     let row = -1;
     let preMod = 0;
     let colIndex = 0;
+
+    function setPickedMap(bm, event) {
+        if (lastPicked !== null) {
+            lastPicked.blinkoverlay.style.animation = 'none';
+        }
+        lastPicked = bm;
+        bm.pickedStatus.style.color = '#f5f5f5';
+        bm.overlay.style.opacity = event.ctrlKey ? '0.95' : '0.85';
+        bm.blinkoverlay.style.animation = event.ctrlKey ?
+            'none' : 'blinker 1s cubic-bezier(.36,.06,.01,.57) 300ms 8, slowPulse 5000ms ease-in-out 8000ms infinite';
+        bm.artist.style.opacity = '0.3';
+        bm.title.style.opacity = '0.3';
+        bm.difficulty.style.opacity = '0.3';
+        bm.modIcon.style.opacity = '0.3';
+        bm.bg.style.opacity = '0';
+    }
+
+    function resetMapPick(bm) {
+        bm.overlay.style.opacity = '0.5';
+        bm.blinkoverlay.style.animation = 'none';
+        bm.artist.style.opacity = '1';
+        bm.title.style.opacity = '1';
+        bm.difficulty.style.opacity = '1';
+        bm.modIcon.style.opacity = '1';
+        bm.bg.style.opacity = '1';
+        bm.pickedStatus.style.opacity = '0';
+        bm.pickedStatus.style.boxShadow = 'none';
+        bm.pickedStatus.style.outline = 'none';
+    }
+
     bms.map(async (beatmap, index) => {
         if (beatmap.mods !== preMod || colIndex % 3 === 0) {
             preMod = beatmap.mods;
@@ -190,35 +220,14 @@ async function setupBeatmaps() {
         bm.clicker.addEventListener('mousedown', function () {
             bm.clicker.addEventListener('click', function (event) {
                 if (!event.shiftKey) {
-                    if (lastPicked !== null) {
-                        lastPicked.blinkoverlay.style.animation = 'none';
-                    }
-                    lastPicked = bm;
-                    bm.pickedStatus.style.color = '#f5f5f5';
-                    bm.overlay.style.opacity = event.ctrlKey ? '0.95' : '0.85';
-                    bm.blinkoverlay.style.animation = event.ctrlKey ?
-                        'none' : 'blinker 1s cubic-bezier(.36,.06,.01,.57) 300ms 8, slowPulse 5000ms ease-in-out 8000ms infinite';
-                    bm.artist.style.opacity = '0.3';
-                    bm.title.style.opacity = '0.3';
-                    bm.difficulty.style.opacity = '0.3';
-                    bm.modIcon.style.opacity = '0.3';
-                    bm.bg.style.opacity = '0';
+                    setPickedMap(bm, event);
                     setTimeout(function () {
                         bm.pickedStatus.style.opacity = '1';
                         bm.pickedStatus.style.outline = bm.mods.includes("TB") ? "3px solid #FFF" : event.ctrlKey ? 'none' : '3px solid #ff8d8d';
                         bm.pickedStatus.innerHTML = bm.mods.includes("TB") ? "Tiebreaker triggered" : event.ctrlKey ? `<b class="pickRed">${redName}</b> ban` : `<b class="pickRed">${redName}</b> pick`;
                     }, 300);
                 } else {
-                    bm.overlay.style.opacity = '0.5';
-                    bm.blinkoverlay.style.animation = 'none';
-                    bm.artist.style.opacity = '1';
-                    bm.title.style.opacity = '1';
-                    bm.difficulty.style.opacity = '1';
-                    bm.modIcon.style.opacity = '1';
-                    bm.bg.style.opacity = '1';
-                    bm.pickedStatus.style.opacity = '0';
-                    bm.pickedStatus.style.boxShadow = 'none';
-                    bm.pickedStatus.style.outline = 'none';
+                    resetMapPick(bm);
                     setTimeout(function () {
                         bm.pickedStatus.style.opacity = '1';
                         bm.pickedStatus.innerHTML = '';
@@ -227,35 +236,14 @@ async function setupBeatmaps() {
             });
             bm.clicker.addEventListener('contextmenu', function (event) {
                 if (!event.shiftKey) {
-                    if (lastPicked !== null) {
-                        lastPicked.blinkoverlay.style.animation = 'none';
-                    }
-                    lastPicked = bm;
-                    bm.pickedStatus.style.color = '#f5f5f5';
-                    bm.overlay.style.opacity = event.ctrlKey ? '0.95' : '0.85';
-                    bm.blinkoverlay.style.animation = event.ctrlKey ?
-                        'none' : 'blinker 1s cubic-bezier(.36,.06,.01,.57) 300ms 8, slowPulse 5000ms ease-in-out 8000ms infinite';
-                    bm.artist.style.opacity = '0.3';
-                    bm.title.style.opacity = '0.3';
-                    bm.difficulty.style.opacity = '0.3';
-                    bm.modIcon.style.opacity = '0.3';
-                    bm.bg.style.opacity = '0';
+                    setPickedMap(bm, event);
                     setTimeout(function () {
                         bm.pickedStatus.style.opacity = '1';
                         bm.pickedStatus.style.outline = bm.mods.includes("TB") ? "3px solid #FFF" : event.ctrlKey ? 'none' : '3px solid #93b5ff';
                         bm.pickedStatus.innerHTML = bm.mods.includes("TB") ? "Tiebreaker triggered" : event.ctrlKey ? `<b class="pickBlue">${blueName}</b> ban` : `<b class="pickBlue">${blueName}</b> pick`;
                     }, 150);
                 } else {
-                    bm.overlay.style.opacity = '0.5';
-                    bm.blinkoverlay.style.animation = 'none';
-                    bm.artist.style.opacity = '1';
-                    bm.title.style.opacity = '1';
-                    bm.difficulty.style.opacity = '1';
-                    bm.modIcon.style.opacity = '1';
-                    bm.bg.style.opacity = '1';
-                    bm.pickedStatus.style.opacity = '0';
-                    bm.pickedStatus.style.boxShadow = 'none';
-                    bm.pickedStatus.style.outline = 'none';
+                    resetMapPick(bm);
                     setTimeout(function () {
                         bm.pickedStatus.style.opacity = '1';
                         bm.pickedStatus.innerHTML = '';

--- a/showcase/css/style.css
+++ b/showcase/css/style.css
@@ -201,12 +201,14 @@ html {
 }
 
 #progress {
-    position: absolute;
-    width: 1420px;
-    height: 160px;
+	position: absolute;
+	width: calc(2 * 1420px);
+	height: 160px;
 	transition: linear 500ms;
-    padding: 0;
-    left: 0;
-    bottom: 0;
-    overflow: hidden;
+	padding: 0;
+	left: 0;
+	bottom: 0;
+	overflow: hidden;
+	-webkit-mask-image: linear-gradient(90deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 49.75%, transparent 50%);
+	mask-image: linear-gradient(90deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 49.75%, transparent 50%);
 }

--- a/showcase/index.js
+++ b/showcase/index.js
@@ -139,8 +139,9 @@ socket.onmessage = async event => {
 	if (seek !== data.menu.bm.time.current && fulltime !== undefined && fulltime != 0 && now - last_strain_update > 500) {
 		last_strain_update = now;
 		seek = data.menu.bm.time.current;
-		let width = onepart * seek + 'px';
-		progressChart.style.width = width;
+		let maskPosition = `${-1420 + onepart * seek}px 0px`;
+		progressChart.style.maskPosition = maskPosition;
+		progressChart.style.webkitMaskPosition = maskPosition;
 	}
 }
 


### PR DESCRIPTION
The idea behind the slow pulse is for a map is picked but the teams take a while to decide who's going to play. The slow pulse helps identify the latest pick at a glance without being as jarring as the fast blinker animation when the map is first picked; while the bottom bar _does_ show the currently picked map, it doesn't tell which mod/slot it's from which hopefully makes it nicer for those unfamiliar with the pool. 

Thoughts? Can re-open another to only include smooth progress and discard this.

https://user-images.githubusercontent.com/1176059/226449702-ddf1879f-32d2-4cf4-82c0-fae597d527db.mp4


____
This PR also adds smooth progress to the showcase scene, as well as a slight cleanup of the map pick code.