### PR TITLE
Trim strain graph to map drain time

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -291,7 +291,7 @@ socket.onmessage = event => {
 	}
 
 	let now = Date.now();
-	if (fulltime !== data.menu.bm.time.full - data.menu.bm.time.firstObj) {
+	if (fulltime !== Math.floor((strainsEndFraction - strainsStartFraction) * data.menu.bm.time.mp3)) {
 		fulltime = Math.floor((strainsEndFraction - strainsStartFraction) * data.menu.bm.time.mp3);
 	}
 	if (fulltime !== undefined && fulltime !== 0 && now - last_strain_update > 500) {

--- a/main/index.js
+++ b/main/index.js
@@ -275,11 +275,14 @@ socket.onmessage = event => {
 	}
 
 	let now = Date.now();
-	if (fulltime !== data.menu.bm.time.mp3) { fulltime = data.menu.bm.time.mp3; onepart = 1220 / fulltime; }
-	if (seek !== data.menu.bm.time.current && fulltime !== undefined && fulltime != 0 && now - last_strain_update > 500) {
+	if (fulltime !== data.menu.bm.time.fulltime - data.menu.bm.time.firstObj) {
+		fulltime = data.menu.bm.time.fulltime - data.menu.bm.time.firstObj;
+		onepart = 1220 / fulltime;
+	}
+	if (seek !== data.menu.bm.time.current && fulltime !== undefined && fulltime !== 0 && now - last_strain_update > 500) {
 		last_strain_update = now;
 		seek = data.menu.bm.time.current;
-		if (scoreRed == 0 || scoreBlue == 0) {
+		if (scoreRed === 0 || scoreBlue === 0) {
 			progressChart.style.maskPosition = '-1220px 0px';
 			progressChart.style.webkitMaskPosition = '-1220px 0px';
 		}

--- a/main/index.js
+++ b/main/index.js
@@ -187,7 +187,16 @@ socket.onmessage = event => {
 			strains = JSON.stringify(data.menu.pp.strains);
 			if (!strains) return;
 
-			let temp_strains = smooth(data.menu.pp.strains, 3);
+			strains = data.menu.pp.strains
+
+			let startTime = data.menu.bm.time.firstObj;
+			let endTime = data.menu.bm.time.full;
+			let mp3Time = data.menu.bm.time.mp3;  // full duration of song
+			if (endTime/mp3Time < 0.95) {
+				strains = strains.slice(Math.floor(strains.length * (startTime/mp3Time)), Math.floor(strains.length * (0.05 + endTime/mp3Time)));
+			}
+
+			let temp_strains = smooth(strains, 3);
 			let new_strains = [];
 			for (let i = 0; i < Math.min(temp_strains.length, 400); i++) {
 				new_strains.push(temp_strains[Math.floor(i * (temp_strains.length / Math.min(temp_strains.length, 400)))]);
@@ -279,10 +288,10 @@ socket.onmessage = event => {
 		fulltime = data.menu.bm.time.full - data.menu.bm.time.firstObj;
 		onepart = 1220 / fulltime;
 	}
-	if (seek !== data.menu.bm.time.current && fulltime !== undefined && fulltime !== 0 && now - last_strain_update > 500) {
+	if (seek !== data.menu.bm.time.current - data.menu.bm.time.firstObj && fulltime !== undefined && fulltime !== 0 && now - last_strain_update > 500) {
 		last_strain_update = now;
-		seek = data.menu.bm.time.current;
-		if (scoreRed === 0 || scoreBlue === 0) {
+		seek = data.menu.bm.time.current - data.menu.bm.time.firstObj;
+		if (scoreRed === 0 || scoreBlue === 0 || seek < 0) {
 			progressChart.style.maskPosition = '-1220px 0px';
 			progressChart.style.webkitMaskPosition = '-1220px 0px';
 		}

--- a/main/index.js
+++ b/main/index.js
@@ -109,7 +109,7 @@ window.setInterval(() => {
 		}
 	}
 
-	console.log(checkValid())
+	// console.log(checkValid())
 	if (checkValid() !== 0) {
 		// image_container.style.border = "48px solid rgba(255,255,255,0)";  // uncomment for triangle fold animation
 		image_container.style.borderLeft = "48px solid rgba(255,255,255,0)";  // comment out for triangle fold animation
@@ -275,8 +275,8 @@ socket.onmessage = event => {
 	}
 
 	let now = Date.now();
-	if (fulltime !== data.menu.bm.time.fulltime - data.menu.bm.time.firstObj) {
-		fulltime = data.menu.bm.time.fulltime - data.menu.bm.time.firstObj;
+	if (fulltime !== data.menu.bm.time.full - data.menu.bm.time.firstObj) {
+		fulltime = data.menu.bm.time.full - data.menu.bm.time.firstObj;
 		onepart = 1220 / fulltime;
 	}
 	if (seek !== data.menu.bm.time.current && fulltime !== undefined && fulltime !== 0 && now - last_strain_update > 500) {

--- a/main/index.js
+++ b/main/index.js
@@ -109,7 +109,6 @@ window.setInterval(() => {
 		}
 	}
 
-	// console.log(checkValid())
 	if (checkValid() !== 0) {
 		// image_container.style.border = "48px solid rgba(255,255,255,0)";  // uncomment for triangle fold animation
 		image_container.style.borderLeft = "48px solid rgba(255,255,255,0)";  // comment out for triangle fold animation
@@ -308,7 +307,6 @@ socket.onmessage = event => {
 					0.,
 					data.menu.bm.time.current - data.menu.bm.time.mp3 * strainsStartFraction)/fulltime
 			);
-			console.log(strainsStartFraction, strainsEndFraction, seek)
 			let maskPosition = `${-1220 + 1220 * seek}px 0px`;
 			progressChart.style.maskPosition = maskPosition;
 			progressChart.style.webkitMaskPosition = maskPosition;
@@ -477,7 +475,7 @@ let configProgress = {
 		labels: [],
 		datasets: [{
 			borderColor: 'rgba(245, 245, 245, 0)',
-			backgroundColor: 'rgba(255, 255, 255, 0.15)',
+			backgroundColor: 'rgba(255, 255, 255, 0.22)',
 			data: [],
 			fill: true,
 		}]

--- a/showcase/index.js
+++ b/showcase/index.js
@@ -33,7 +33,7 @@ socket.onerror = error => { console.log('Socket Error: ', error); };
 
 let image, title_, diff_, artist_, replay_, id;
 let len_, bpm_, sr_, cs_, ar_, od_;
-let strains, seek, fulltime;
+let strains, seek, fulltime, strainsStartFraction, strainsEndFraction;
 let state;
 let last_strain_update = 0;
 
@@ -118,7 +118,24 @@ socket.onmessage = async event => {
 	if (strains != JSON.stringify(data.menu.pp.strains) && window.strainGraph) {
 		strains = JSON.stringify(data.menu.pp.strains) || null;
 
-		let temp_strains = smooth(data.menu.pp.strains, 3);
+		strains = data.menu.pp.strains
+
+		let startTime = data.menu.bm.time.firstObj;
+		let endTime = data.menu.bm.time.full;
+		let mp3Time = data.menu.bm.time.mp3;  // full duration of song
+
+		if (endTime/mp3Time < 0.95 || startTime/mp3Time > 0.05) {  // don't trim if trim amount < 5% on either side
+			strainsStartFraction = Math.max(0,
+				-0.05 + // add padding to account for smoothing
+				startTime/mp3Time);
+			strainsEndFraction = Math.min(1.00, 0.05 + endTime/mp3Time);  // idem
+			strains = strains.slice(Math.floor(strains.length * strainsStartFraction), Math.floor(strains.length * strainsEndFraction));
+		} else {
+			strainsStartFraction = 0.;
+			strainsEndFraction = 1.;
+		}
+
+		let temp_strains = smooth(strains, 3);
 		let new_strains = [];
 		for (let i = 0; i < Math.min(temp_strains.length, 400); i++) {
 			new_strains.push(temp_strains[Math.floor(i * (temp_strains.length / Math.min(temp_strains.length, 400)))]);
@@ -135,11 +152,18 @@ socket.onmessage = async event => {
 	}
 
 	let now = Date.now();
-	if (fulltime !== data.menu.bm.time.mp3) { fulltime = data.menu.bm.time.mp3; onepart = 1420 / fulltime; }
-	if (seek !== data.menu.bm.time.current && fulltime !== undefined && fulltime != 0 && now - last_strain_update > 500) {
+	if (fulltime !== Math.floor((strainsEndFraction - strainsStartFraction) * data.menu.bm.time.mp3)) {
+		fulltime = Math.floor((strainsEndFraction - strainsStartFraction) * data.menu.bm.time.mp3);
+	}
+	if (fulltime !== undefined && fulltime !== 0 && now - last_strain_update > 500) {
 		last_strain_update = now;
-		seek = data.menu.bm.time.current;
-		let maskPosition = `${-1420 + onepart * seek}px 0px`;
+		seek = Math.min(
+			1.,
+			Math.max(
+				0.,
+				data.menu.bm.time.current - data.menu.bm.time.mp3 * strainsStartFraction)/fulltime
+		);
+		let maskPosition = `${-1220 + 1220 * seek}px 0px`;
 		progressChart.style.maskPosition = maskPosition;
 		progressChart.style.webkitMaskPosition = maskPosition;
 	}

--- a/showcase/index.js
+++ b/showcase/index.js
@@ -163,7 +163,7 @@ socket.onmessage = async event => {
 				0.,
 				data.menu.bm.time.current - data.menu.bm.time.mp3 * strainsStartFraction)/fulltime
 		);
-		let maskPosition = `${-1220 + 1220 * seek}px 0px`;
+		let maskPosition = `${-1420 + 1420 * seek}px 0px`;
 		progressChart.style.maskPosition = maskPosition;
 		progressChart.style.webkitMaskPosition = maskPosition;
 	}


### PR DESCRIPTION
If a map has a long section before the first note and/or after the last note, the strain graph is squeezed to the center. This attempts to trim the strain graph where there is no map.